### PR TITLE
deprecate the sun-sdk

### DIFF
--- a/sun-sdk/README.md
+++ b/sun-sdk/README.md
@@ -1,1 +1,22 @@
-# sun-cli
+# ⚠️ Deprecated Repository
+
+> **This project is no longer maintained.**
+
+Thank you for your interest in this repository. Please note that this project has been **officially deprecated** and is no longer actively maintained.
+
+### 📦 Latest Version
+
+The latest version of this project has been included in the official release of the [Sun Network v1.5.2](https://github.com/tronprotocol/sun-network/releases/tag/SunNetwork-v1.5.2).  
+Please refer to that repository for the most up-to-date code, documentation, and support.
+
+---
+
+### ❌ Deprecation Notice
+
+This repository is kept for historical reference only. You are still welcome to explore the code, but:
+
+- **No further updates will be made**
+- **Issues and pull requests will not be reviewed**
+- **The code is provided as-is, without support**
+
+---


### PR DESCRIPTION
This PR marks the official deprecation of the `sun-sdk`.

### Reasons for deprecation:

- The project is no longer maintained

- Functionality has been migrated to another repository

- To prevent further usage or dependency on outdated code

### Changes in this PR:

- Added a deprecation notice to `README.md`